### PR TITLE
ci: pin every CI dependency to an exact version

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -8,12 +8,12 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.actor == 'dependabot[bot]' # Only run for Dependabot PRs
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,11 +9,13 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,11 +5,11 @@ on:
 jobs:
   markdown:
     name: markdown linting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install dependencies
@@ -19,13 +19,15 @@ jobs:
       - name: Lint Markdown
         run: bun run md:lint
   biome:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          version: latest
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - name: Run Biome
-        run: biome ci .
+        run: bunx biome ci .

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -20,7 +20,7 @@ jobs:
       # release pull request this opens actually runs the build, test and lint
       # workflows. Events raised by GITHUB_TOKEN start no further workflow, so
       # with it the release pull request would sit there untested.
-      - uses: googleapis/release-please-action@v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
@@ -35,22 +35,22 @@ jobs:
   goreleaser:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the tag release-please just created
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.3
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: "2.17.1"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,17 @@ on: push
 jobs:
   test:
     name: Run tests and collect coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download
@@ -28,6 +30,6 @@ jobs:
         run: go test ./... -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fifth of nine. Merge after #4.

Every `uses:` here named a tag. A tag is a mutable pointer. Whoever controls the
action can move `actions/checkout@v7` whenever they like, and the next run picks
up whatever it points at, unreviewed. A commit SHA can't move.

So each one is pinned to its full SHA with the tag it resolved to in a trailing
comment. Dependabot understands this form and raises pull requests against it,
which is how upgrades arrive where the tests can see them.

The same reasoning goes past the actions themselves, to the tools they install:

Biome came from `biomejs/setup-biome` at `version: latest`, so CI could lint
against a different Biome than the hooks, which run the 2.5.3 in the lockfile.
The action goes and CI runs the lockfile's Biome through `bunx`. One pinned
version, one fewer action to trust.

`golangci-lint-action` had no version, so it took the newest release every run.
Now pinned to the 2.12.2 the hooks use.

`setup-go` asked for `stable` in three workflows and for nothing at all in a
fourth. All four now read `go-version-file: go.mod`, so the toolchain is pinned
by a committed file that dependabot's gomod ecosystem already maintains.

goreleaser came in on the `"~> v2"` range and is now 2.17.1.

The runner image was a mix of `ubuntu-latest` and `ubuntu-22.04`. That's two
jobs on different images for no stated reason, plus a third that silently moves
with GitHub's default. All jobs are on `ubuntu-24.04`.
