### PR TITLE
chore: bring the linter configs up to date with their pinned tools

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   disable:
     - depguard
     - forbidigo
+    - gomodguard
     - varnamelen
     - wsl
 formatters:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -15,7 +15,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	},
 	"javascript": {


### PR DESCRIPTION
Seventh of nine. Merge after #6.

Both linters printed a deprecation notice on every run. In every hook, in every
CI job, and wrapped around the output you were actually trying to read. Warnings
that always fire stop being read, including the ones that matter.

`biome.json` declared the 2.2.6 schema while the lockfile pins Biome 2.5.3, and
used `linter.rules.recommended`, which 2.x replaced with `preset`. I ran
`biome migrate`, so the change is the tool's own rather than mine.

`.golangci.yml` inherited `gomodguard` through `default: all`, and it was
deprecated in golangci-lint 2.12 in favour of `gomodguard_v2`. Disabling the old
name is enough, because `default: all` already enables the successor.
`golangci-lint linters` confirms `gomodguard_v2` is on and `gomodguard` is off,
so nothing stops being checked.
