### PR TITLE
docs: add an Example function to wttrclient

### DIFF
--- a/wttrclient/example_test.go
+++ b/wttrclient/example_test.go
@@ -1,0 +1,35 @@
+package wttrclient_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/alrayyes/gwttr/wttrclient"
+)
+
+// A local test server stands in for wttr.in here. Pointing the example at the
+// real service would make its expected output depend on today's weather, and
+// on the network being up when the suite runs.
+func ExampleWTTRClient_CurrentWeather() {
+	srv := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		_, _ = w.Write([]byte("Weather report: honolulu"))
+	}))
+	defer srv.Close()
+
+	client := wttrclient.NewWTTRClient(srv.URL)
+
+	forecast, err := client.CurrentWeather(context.Background())
+	if err != nil {
+		fmt.Println(err)
+
+		return
+	}
+
+	fmt.Println(forecast)
+	// Output: Weather report: honolulu
+}


### PR DESCRIPTION
Merge after #10.

`wttrclient`'s doc comments say what `CurrentWeather` does, but nothing showed a
caller how to build a client and use one. An Example is the form that can't go
stale. `go test` runs it as a test, so it fails the build the moment the API it
demonstrates changes, and pkg.go.dev renders it as the documentation.

It's driven by an `httptest` server rather than wttr.in, because the `// Output:`
comment has to be deterministic and no example should need the network.

I checked the assertion is real by changing the expected output and watching it
fail.
