### PR TITLE
chore: ignore node_modules in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gwttr
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+node_modules/
 
 # Go workspace file
 go.work


### PR DESCRIPTION
`.gitignore` covers what this project produces already: `dist/`, build output, `.env`. `node_modules/` was missing, and it's exactly that sort of thing.

It looked fine because a personal `~/.config/git/gitignore_global` was catching it. Anyone else cloning this repo sees `node_modules/` as untracked the moment they run `bun install`, and a project shouldn't depend on a contributor's personal config to have a clean `git status`.

One line. Verified with `git check-ignore -v node_modules`, which now points at `.gitignore:20` rather than the global file.

Closes #213