### PR TITLE
ci: run the tests with the race detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      # -race here and not in the git hooks: the detector makes the suite
+      # noticeably slower, and pre-push has to stay quick enough not to be
+      # resented. lefthook.yml says the same thing from the other side.
       - name: Run tests
-        run: go test ./... -coverprofile=coverage.txt
+        run: go test -race ./... -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,6 +28,8 @@ pre-push:
     # leaves the pushed commit and the working tree disagreeing about what was
     # reviewed.
     - run: golangci-lint fmt --diff ./...
+    # No -race here. The detector is slow enough that it would make every push
+    # wait, so CI runs it instead. See .github/workflows/test.yml.
     - run: go test -cover ./...
 
 pre-commit:


### PR DESCRIPTION
Nothing ran `go test -race`. Our own code spawns no goroutines, but the suite starts `httptest` servers, which are real servers with real goroutines, so the detector has something to look at.

It goes in CI and not the hooks. I measured it: the suite goes from 317ms to 1406ms. That's nothing in absolute terms today, but it's 4.4x, and the ratio is what matters once there are more tests. `pre-push` has to stay quick enough that nobody reaches for `--no-verify`.

That makes it a deliberate difference between hook and CI rather than the drift we've spent several PRs removing, so both files carry a comment explaining it and pointing at the other. Otherwise the next person reads it as an oversight and "fixes" it.

Closes #212