### PR TITLE
fix: remove duplicate with block in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,5 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-        with:
-          go-version-file: go.mod
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
**The Build workflow has been failing on `main`, and this is my fault.**

`build.yml` has a duplicated `with:` key:

```yaml
      - name: Set up Go
        uses: actions/setup-go@b7ad1da... # v7.0.0
        with:
          go-version-file: go.mod
        with:            # <- duplicate
          go-version-file: go.mod
```

That's invalid YAML, so GitHub can't parse the file and never gets as far as running it. The tell is that the run shows up named `.github/workflows/build.yml` rather than `Build`: GitHub falls back to the path when it can't read `name:`.

I introduced it while resolving the conflict between dependabot's setup-go v7.0.0 bump and my SHA pin. The regex I used appended a `with:` block to a step that already had one.

The check I ran at the time used `yaml.safe_load`, which silently accepts duplicate keys and keeps the last one, so it told me the file was fine. A loader that rejects duplicates catches it immediately, and I've verified the other five workflows with that stricter check. Only this one was affected.