### PR TITLE
fix: remove the release that never happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ### Bug Fixes
 
-* remove duplicate with block in build.yml ([911dde0](https://github.com/alrayyes/gwttr/commit/911dde00522adb11c9d9ef742f29016e158f0102))
 * remove duplicate with block in build.yml ([3e7e2ca](https://github.com/alrayyes/gwttr/commit/3e7e2caddf0ac8af00b5fed6b8afacd4a73c13d2))
 
 ## [1.2.1](https://github.com/alrayyes/gwttr/compare/v1.2.0...v1.2.1) (2026-08-12)
@@ -14,22 +13,7 @@
 ### Bug Fixes
 
 * **ci:** use latest golangci-lint version in pipeline ([84278c0](https://github.com/alrayyes/gwttr/commit/84278c0c206c878e11feb1e9b281f5dae169d221))
-* restage what the pre-commit hooks fix ([642e209](https://github.com/alrayyes/gwttr/commit/642e2093e84b8e57145b489776a09c0517f1ed4d))
 * restage what the pre-commit hooks fix ([bb9081c](https://github.com/alrayyes/gwttr/commit/bb9081cd6010afebe1f8f5565d1c3dde4298acdf))
-
-## 1.0.0 (2026-08-12)
-
-
-### Features
-
-* return the actual weather for Honolulu ([60db99c](https://github.com/alrayyes/gwttr/commit/60db99cccdb48b4601272e4779852754557c8973))
-* set timeout to 5 seconds ([e71b00c](https://github.com/alrayyes/gwttr/commit/e71b00cf67a1f435761ce8f31e7de61076fe392f))
-* tell the user we have no idea what the weather is ([0086e02](https://github.com/alrayyes/gwttr/commit/0086e02c25f3ed0159e40a15b3b0fb23540181da))
-
-
-### Bug Fixes
-
-* **ci:** use latest golangci-lint version in pipeline ([84278c0](https://github.com/alrayyes/gwttr/commit/84278c0c206c878e11feb1e9b281f5dae169d221))
 
 ## [1.2.0](https://github.com/alrayyes/gwttr/compare/v1.1.0...v1.2.0) (2025-02-18)
 


### PR DESCRIPTION
`CHANGELOG.md` claimed a `1.0.0 (2026-08-12)` release, listing features that actually shipped in 1.0.0, 1.1.0 and 1.2.0 back in February 2025. No tag was ever created for it, so the changelog was the only thing saying it happened.

release-please wrote that while `main` still configured it inline with `release-type: go` and no manifest, so it had nothing authoritative telling it where the version was and counted from zero. That's fixed now: with the manifest in place, 1.2.1 and 1.2.2 both came out correctly, so this is cleaning up after the one bad run rather than an ongoing problem.

Two other artefacts of the same run, while I was in the file:

- **Two entries appeared twice**, once against the merge commit and once against the commit that carried the change. I kept the latter.
- **The `golangci-lint` entry under 1.2.1 stays.** It looks like it drifted in from an old release, and I nearly removed it. It didn't: `84278c0` landed in October 2025, after v1.2.0 was cut, and had never been released until 1.2.1. Checking that before deleting it was worth the minute.

Nothing here touches a tag or a release. Only the file.

Closes #231