### PR TITLE
chore: point the biome schema at the installed copy

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",


### PR DESCRIPTION
`biome.json` pinned its schema URL to an exact version, so every Biome bump left it stale:

```
The configuration schema version does not match the CLI version 2.5.7
Expected: 2.5.7
Found:    2.5.3
```

That fired on every hook run and every CI job. It had already drifted three times, and it was never going to stop, because dependabot updates `package.json` and has no idea the version is also spelled out inside a URL in another file. A warning that always fires stops being read, which is the actual cost.

The Biome package ships its own schema, so `biome.json` now points at that. The schema is whatever the lockfile installed, which means it can't drift and there's nothing left to maintain.

I did consider `https://biomejs.dev/schemas/latest/schema.json`. It resolves fine, but it's a floating pointer at a remote file, and we've just spent several PRs pinning everything else in this repo.

Verified with both `biome check .` and `biome ci .` — the warning is gone and nothing else changed.

Closes #232