### PR TITLE
feat: report the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Give it a location for anywhere else. Quote anything with a space in it:
 ./gwttr "new york"
 ```
 
-`./gwttr --help` lists the flags.
+`./gwttr --help` lists the flags, and `./gwttr --version` reports the release
+you're running.
 
 You can use the `wttrclient` package on its own if you just want the forecast as
 a string. The

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@ import (
 
 const defaultLocation = "honolulu"
 
+// version is set at build time by goreleaser's default ldflags, which pass
+// -X main.version=<tag>. A build that isn't a release says so rather than
+// claiming a version it hasn't got.
+var version = "dev"
+
 func main() {
 	cmd := &cobra.Command{
 		Use:   "gwttr [location]",
@@ -22,6 +27,7 @@ func main() {
 			defaultLocation + ".",
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
+		Version:      version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			location := defaultLocation
 			if len(args) == 1 {


### PR DESCRIPTION
Stacked on #238. Merge that one first.

goreleaser's default ldflags have always passed `-X main.version=<tag>`, but no such variable existed. The release version went nowhere, and there was no way to ask a binary which one you were running.

cobra turns its `Version` field into a `--version` flag for free, so this is just the variable and the field that reads it.

```shell
$ gwttr --version          # a plain go build
gwttr version dev

$ gwttr --version          # built the way goreleaser builds it
gwttr version 1.2.3
```

Unreleased builds say `dev` rather than claiming a version they haven't got. I verified both paths by building with and without the ldflag.