### PR TITLE
feat: report the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Give it a location for anywhere else. Quote anything with a space in it:
 ./gwttr "new york"
 ```
 
-`./gwttr --help` lists the flags.
+`./gwttr --help` lists the flags, and `./gwttr --version` reports the release
+you're running.
 
 You can use the `wttrclient` package on its own if you just want the forecast as
 a string. The

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@ import (
 
 const defaultLocation = "honolulu"
 
+// version is set at build time by goreleaser's default ldflags, which pass
+// -X main.version=<tag>. A build that isn't a release says so rather than
+// claiming a version it hasn't got.
+var version = "dev"
+
 func main() {
 	cmd := &cobra.Command{
 		Use:   "gwttr [location]",
@@ -22,6 +27,7 @@ func main() {
 			defaultLocation + ".",
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
+		Version:      version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			location := defaultLocation
 			if len(args) == 1 {


### PR DESCRIPTION
**#239 was merged into the wrong branch and never reached `main`.** This is the same commit, reapplied on top of `main`.

#238 merged into `main` at 07:54:49. #239 merged into `feat/location-argument` seventeen seconds later, at 07:55:06 — by which point that branch had already been merged and was orphaned. The PR shows as merged and the work looked done, but `main.go` on `main` has no `Version` field and `gwttr --version` doesn't exist.

The change itself is unchanged from what you reviewed on #239:

goreleaser's default ldflags have always passed `-X main.version=<tag>`, but no such variable existed, so the release version went nowhere.

```shell
$ gwttr --version          # a plain go build
gwttr version dev

$ gwttr --version          # built the way goreleaser builds it
gwttr version 1.2.3
```

I rebuilt both ways again on this branch to confirm it still behaves the same after the cherry-pick.