### PR TITLE
chore: check with one biome command, not two

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,4 +30,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Run Biome
-        run: bunx biome ci .
+        # The same script the pre-push hook runs, so what Biome checks is
+        # defined once. --reporter=github is all `biome ci` was adding here:
+        # it puts the findings on the diff as annotations. It still never
+        # writes, because `check` without --write doesn't.
+        run: bun run lint . --reporter=github


### PR DESCRIPTION
CI ran `biome ci .` while the pre-push hook ran `bun run lint .` (`biome check`). Two commands, two ideas of what gets checked, and nothing keeping them agreed — the hook could go green on a rule CI doesn't run, or the other way round, and neither file tells you that's happening.

CI calls the same script now. `--reporter=github` is the only thing `biome ci` was buying us over `check`: it puts findings on the diff as annotations. I checked that rather than assuming it — ran both against a deliberately misformatted file, and `check --reporter=github` emits the same `::error title=…file=…line=…` annotations `biome ci` does. It still can't write, because `check` without `--write` doesn't.