### PR TITLE
fix: let biome read the gitignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"files": {
 		"ignoreUnknown": false


### PR DESCRIPTION
`bun run lint` fails on a clean checkout the moment `vale sync` has run —
Biome formats `styles/Google/meta.json` and `styles/proselint/meta.json`, which
are downloaded packages nobody wrote.

`.gitignore` already names both directories. Biome just wasn't reading it:
`vcs.enabled` and `useIgnoreFile` were both `false`, so the keys were sitting
there doing nothing.

CI hides this. The prose job syncs the styles and the lint job runs Biome, and
they're separate checkouts, so the machine that downloads them isn't the machine
that lints them. The pre-push hook is where it actually bites.

The alternative was listing the two paths in `biome.json` as well, which is the
same ignore list written twice and one of them will go stale the next time a
Vale package is added.

Closes #246
