### PR TITLE
fix: stop merge commits duplicating every changelog entry

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,14 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # This repo rebases pull requests rather than merging them, and that is a
+      # requirement rather than a preference. GitHub writes the pull request
+      # title into the body of a merge commit, release-please reads conventional
+      # commits out of a commit body as well as its subject, and so every change
+      # landed by a merge commit was listed twice in the changelog. Merge commits
+      # are switched off in the repository settings; no combination of GitHub's
+      # merge commit settings leaves that body empty.
+      #
       # The token is a PAT rather than the default GITHUB_TOKEN so that the
       # release pull request this opens actually runs the build, test and lint
       # workflows. Events raised by GITHUB_TOKEN start no further workflow, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ### Features
 
-* report the version ([ad4088e](https://github.com/alrayyes/gwttr/commit/ad4088e9ac1b4fdc20c3c2bc318ef525dbd2a9df))
 * report the version ([1819985](https://github.com/alrayyes/gwttr/commit/181998580652fa4ff22face34cbf2a8c6f212adc))
 
 ## [1.3.0](https://github.com/alrayyes/gwttr/compare/v1.2.3...v1.3.0) (2026-08-12)
@@ -13,7 +12,6 @@
 
 ### Features
 
-* take the location as an argument ([f4a1617](https://github.com/alrayyes/gwttr/commit/f4a16173f3ee77120dc327bfe0373ba0d1ca1f30))
 * take the location as an argument ([e672908](https://github.com/alrayyes/gwttr/commit/e67290819a6380a0396769a3b73fa69ba6c7671f)), closes [#210](https://github.com/alrayyes/gwttr/issues/210)
 
 ## [1.2.3](https://github.com/alrayyes/gwttr/compare/v1.2.2...v1.2.3) (2026-08-12)
@@ -22,7 +20,6 @@
 ### Bug Fixes
 
 * check the prose as British English ([f0e74db](https://github.com/alrayyes/gwttr/commit/f0e74db87750589d9aa334c8066516b56dc75f0e))
-* remove the release that never happened ([cea2f0c](https://github.com/alrayyes/gwttr/commit/cea2f0c6a7c4a05cf9383bc219284b7c8e11b833))
 * remove the release that never happened ([f535e54](https://github.com/alrayyes/gwttr/commit/f535e54bec2977f14dec8898596a0885c10ff217)), closes [#231](https://github.com/alrayyes/gwttr/issues/231)
 * run ltex against its own bundled jdk ([eed5b6b](https://github.com/alrayyes/gwttr/commit/eed5b6b7293c55b8112e4185351492dd8be1ffa9))
 


### PR DESCRIPTION
The 1.4.0, 1.3.0 and 1.2.3 sections each list the same change twice.

GitHub writes the pull request title into the *body* of a merge commit, and
release-please pulls conventional commits out of a commit body as well as its
subject, so each change gets counted once for the real commit and once for the
merge that landed it. The entries that came in without a merge commit —
"check the prose as British English", "run ltex against its own bundled jdk" —
are the ones that appear only once, which is the tell.

There's no setting that leaves the merge commit body empty. GitHub only accepts
`PR_TITLE`+`PR_BODY`, `PR_TITLE`+`BLANK` and `MERGE_MESSAGE`+`PR_TITLE`, and the
first two move the conventional commit into the subject line where
release-please still finds it. No release-please config for it either; the body
parsing came in with
[release-please#2358](https://github.com/googleapis/release-please/pull/2358)
and has no off switch.

Squash merges are what release-please officially recommends, but they'd collapse
each branch into a single commit. Rebase merges give the same linear history and
keep the commits, so merge and squash are now off in the settings and
Dependabot's auto-merge asks for `--rebase`.

Neither commit is a `fix:`, so this doesn't cut a release.

Stacked on #247, which had to land first — Biome was failing the pre-push hook
on Vale's downloaded style packages, so there was no way to push this.

Closes #245
