### PR TITLE
ci: run every workflow on pull requests and on main, and nowhere else

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,9 @@
 name: golangci-lint
 on:
   push:
+    branches: ["main"]
   pull_request:
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,9 @@
 name: Linting
 on:
   push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   markdown:

--- a/.github/workflows/prose.yml
+++ b/.github/workflows/prose.yml
@@ -2,6 +2,9 @@ name: Prose
 
 on:
   push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   # Style. Vale reports and does not fail the build: style advice that blocks a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run tests and upload coverage
 
-on: push
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ CI runs the same commands, so a green hook should mean a green pipeline. The one
 check that isn't in a hook is LTeX, the grammar tier, which runs in
 [`prose.yml`](.github/workflows/prose.yml).
 
+Every workflow fires on a pull request and on a push to `main`, and nowhere
+else, so each check runs once rather than once per event. A branch pushed with
+no pull request open gets nothing from CI. By then the hooks have run everything
+but LTeX, and nothing merges without a pull request anyway.
+
 You can run any of them by hand:
 
 ```shell


### PR DESCRIPTION
Closes #252

Two problems, one shape to fix them.

`golangci-lint.yml` had a bare `push:` and a bare `pull_request:` with no branch filter, so every commit pushed to a branch with a pull request open got linted twice. On #251 that was runs `31783727924` (push, 32s) and `31783750027` (pull_request, 38s) — same commit, same answer.

`linting.yml`, `prose.yml` and `test.yml` had the opposite problem: `on: push` and nothing else. Between them they produce five of the seven contexts the branch ruleset requires. That works only while every branch lives in this repo. A pull request from a fork pushes nothing here, so those five would never arrive — and a required check that never arrives doesn't fail, it waits, with nothing to read. That's #244 again, one layer down.

`build.yml` already had the shape the others wanted, so they all match it now.

## What this costs

A branch pushed with no pull request open gets nothing from CI. That's the trade for each check running once instead of twice, and it's a cheap one: the pre-push hook has already run build, tests, `golangci-lint run`, `golangci-lint fmt --diff`, Biome, Prettier, markdownlint and Vale by that point. Only LTeX waits for the pull request, and nothing merges without one anyway. CONTRIBUTING says so now.

## What it doesn't touch

Job names, so ruleset `3700037` needs no edit. `release-please.yml` stays on pushes to `main`, and `auto-merge-dependabot.yml` stays on `pull_request`.

## Checking it

This pull request is the test. Every required context should appear exactly once, and `gh run list --branch ci/one-run-per-check` should show one `golangci-lint` run per commit, on the `pull_request` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MYtBNzJoCMwBQKpqcw9Cg