### PR TITLE
docs: say how issues and pull requests get labelled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,17 @@ The tests never reach the network. Everything that speaks HTTP points at a local
 Work lands through a pull request. Please keep it to one change per pull
 request. That's the difference between a review and a rubber stamp.
 
+Label it, and label the issue it closes. Two labels answer it: a kind, and the
+area it touches. The kind falls out of the commit prefix. `fix:` is `bug`,
+`feat:` is `enhancement`, `docs:` is `documentation`, `refactor:` is `refactor`.
+The area is usually `go` or `github_actions`. `gh label list` is the whole set,
+and `gh pr edit <number> -l <label>` puts one on something already open.
+
+Only add a new label when nothing in the set fits. Say so on the pull request,
+and make it one you'd reach for again. A taxonomy invented per ticket is a
+filter nobody can use. Leave `dependencies`, `autorelease: pending` and
+`autorelease: tagged` alone. Dependabot and release-please own those.
+
 ## Releases
 
 Nobody picks a version number here.


### PR DESCRIPTION
I added a `refactor` label to this repo and labelled the whole backlog without anything writing down what the labels mean. That's the shape of a taxonomy nobody can use six months later, so here it is in CONTRIBUTING.

The mapping isn't arbitrary, which is the point worth recording: the kind is already in the conventional-commit prefix, so there's nothing to decide. `fix:` is `bug`, `feat:` is `enhancement`, `docs:` is `documentation`, `refactor:` is `refactor`. The area is `go` or `github_actions` nearly every time.

It also names the three labels a person shouldn't touch — `dependencies`, `autorelease: pending` and `autorelease: tagged` — because Dependabot and release-please put those on themselves.

No issue to close. This came out of applying the convention rather than from a ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MYtBNzJoCMwBQKpqcw9Cg